### PR TITLE
Fix console output in DateWithoutTime

### DIFF
--- a/src/libs/dateWithoutTime.ts
+++ b/src/libs/dateWithoutTime.ts
@@ -27,7 +27,7 @@ export default class DateWithoutTime {
       this.date = moment.utc({ year: _year, month: _month, day: _day}).startOf("day");
     } catch (error) {
         if (error instanceof RangeError) {
-           console.log(`${error.message}: ${_year}-${_month + 1}-${_day}`)
+           console.error(`${error.message}: ${_year}-${_month + 1}-${_day}`)
         }
         throw error;
     }


### PR DESCRIPTION
## Summary
- replace `console.log` with `console.error` in `DateWithoutTime` constructor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68686593d03883319b080d92bea490e6