### PR TITLE
Remove ChristianCalendar namespace

### DIFF
--- a/spec/christian-calendar.test.ts
+++ b/spec/christian-calendar.test.ts
@@ -1,4 +1,12 @@
-import ChristianCalendar from '../src/libs/christian-calendar';
+import {
+  Year,
+  Color,
+  colorize,
+  getSeason,
+  computeAdvent,
+  rclYear,
+  yearFor,
+} from '../src/libs/christian-calendar';
 import DateWithoutTime from '../src/libs/dateWithoutTime';
 
 function idate(dateString: string): DateWithoutTime {
@@ -9,18 +17,18 @@ type SeasonTestCase = {
   name: string;
   startDate: DateWithoutTime;
   endDate: DateWithoutTime;
-  colors: ChristianCalendar.Color[];
-  alternateColors: ChristianCalendar.Color[];
+  colors: Color[];
+  alternateColors: Color[];
 }
 
 function stc(name: string, startDate: string, endDate: string, colors: string[], alternateColors: string[]): SeasonTestCase {
-	return {
-		name: name,
-		startDate: idate(startDate),
-		endDate: idate(endDate),
-		colors: colors.map(ChristianCalendar.colorize),
-		alternateColors: alternateColors.map(ChristianCalendar.colorize)
-	};
+        return {
+                name: name,
+                startDate: idate(startDate),
+                endDate: idate(endDate),
+                colors: colors.map(colorize),
+                alternateColors: alternateColors.map(colorize)
+        };
 }
 
    const cases = [
@@ -53,20 +61,20 @@ function stc(name: string, startDate: string, endDate: string, colors: string[],
 
 describe('Year class', () => {
   it ("Should know its year number and RCL year", () => {
-     const year = new ChristianCalendar.Year(2021);
+     const year = new Year(2021);
      expect(year.year).toBe(2021);
      expect(year.rclYear).toBe('B');
   });    
 
   it ("Should return the correct number of seasons for a given year.", () => { 
-    const year = new ChristianCalendar.Year(2021);
+    const year = new Year(2021);
     const seasons = year.seasons;
     expect(year.seasons).toHaveLength(25);
   });
 
   
   test.each(cases)("The season $name for $startDate should be correctly initialized", (expected) => {
-      const season = ChristianCalendar.getSeason(expected.startDate);
+      const season = getSeason(expected.startDate);
       expect(season).toMatchObject(expected);
   }); // each seasaon
 }); // year
@@ -79,14 +87,14 @@ describe("getSeason", () => {
     [new DateWithoutTime("2020-04-01"), "Lent"],
     [new DateWithoutTime("2020-11-28"), "Christ the King"],
   ])("The season for %p should be %s", (date, expectedSeason) => {
-    expect(ChristianCalendar.getSeason(date).name).toEqual(expectedSeason);
+    expect(getSeason(date).name).toEqual(expectedSeason);
   });
 
   test("The season for 2023-12-24 should be Advent 4", () => {
     // This is an odd case because Christmas Eve and Advent 4 overlap.  Since Advent 4
     // comes before Christmas Eve most years, we want to make sure that the season
     // Advent 4 comes back first.
-    expect(ChristianCalendar.getSeason(new DateWithoutTime("2023-12-24"))).toMatchObject(
+    expect(getSeason(new DateWithoutTime("2023-12-24"))).toMatchObject(
         stc("Advent 4",      "2023-12-24", "2023-12-24",
             ["dark blue", "blue"], ["blue violet", "purple"])
     )
@@ -102,7 +110,7 @@ describe("computeAdvent", () => {
     [2024, new DateWithoutTime("2024-12-01")],
     [2025, new DateWithoutTime("2025-11-30")],
   ])("First Sunday in Advent %i should be %p", (year, expected) => {
-    expect(ChristianCalendar.computeAdvent(Number(year))).toEqual(expected);
+    expect(computeAdvent(Number(year))).toEqual(expected);
   });
 });
 
@@ -116,17 +124,17 @@ describe('RCLYear', () => {
     [2023,'A'],
     [2024,'B']
   ])('RCL year for %d should be %s', (year, expected) => {
-    expect(ChristianCalendar.rclYear(year)).toBe(expected);
+    expect(rclYear(year)).toBe(expected);
   });
 });
 
 describe('Daily Office year', () => {
   test('Daily Office year for 2021 should be 1', () => {
-    let cal = new ChristianCalendar.Year(2021);
+    let cal = new Year(2021);
     expect(cal.dailyOfficeYear).toBe("1");
   });
   test('Daily Office year for 2022 should be 2', () => {
-    let cal = new ChristianCalendar.Year(2022);
+    let cal = new Year(2022);
     expect(cal.dailyOfficeYear).toBe("2");
   });
 });
@@ -142,6 +150,6 @@ describe("yearFor", () => {
     [new DateWithoutTime("2023-09-04"), 2023],
     [new Date("2023/09/04"), 2023]
   ])("The year number for %p should be %i", (date, expectedYear) => {
-    expect(ChristianCalendar.yearFor(date)).toEqual(expectedYear);
+    expect(yearFor(date)).toEqual(expectedYear);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Year from './components/Year';
-import ChristianCalendar from './libs/christian-calendar';
+import { Year as CalendarYear, yearFor } from './libs/christian-calendar';
 import './App.css';
 
 function App() {
-  const [year, setYear] = useState<ChristianCalendar.Year | null>(null);
+  const [year, setYear] = useState<CalendarYear | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -18,11 +18,11 @@ function App() {
       effectiveYear = Math.max(parseInt(yearParam, 10), 1876);
     } else {
       let date = new Date();
-      effectiveYear = ChristianCalendar.yearFor(date);
+      effectiveYear = yearFor(date);
     }
 
 
-    const newYear = new ChristianCalendar.Year(effectiveYear);
+    const newYear = new CalendarYear(effectiveYear);
 
     setYear(newYear);
   }, [location.search]);

--- a/src/components/Color.tsx
+++ b/src/components/Color.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
 import { Tooltip, type ITooltip } from "react-tooltip";
 import { v4 as uuid } from 'uuid';
-import type ChristianCalendar from '../libs/christian-calendar';
+import type { Color as CalendarColor } from '../libs/christian-calendar';
 const TooltipComponent = Tooltip as React.FC<ITooltip>;
 
 interface ColorProps {
-  color: ChristianCalendar.Color;
+  color: CalendarColor;
 }
 const Color: React.FC<ColorProps> = ({ color }) => {
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);

--- a/src/components/Season.tsx
+++ b/src/components/Season.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Color from './Color';
-import type ChristianCalendar from '../libs/christian-calendar';
+import type { Season as CalendarSeason } from '../libs/christian-calendar';
 
 interface SeasonProps {
-  season: ChristianCalendar.Season;
+  season: CalendarSeason;
 }
 const Season: React.FC<SeasonProps> = ({ season }) => {
   const options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };

--- a/src/components/Year.tsx
+++ b/src/components/Year.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Season from './Season';
-import type ChristianCalendar from '../libs/christian-calendar';
+import type { Year as CalendarYear } from '../libs/christian-calendar';
 
 interface YearProps {
-  year: ChristianCalendar.Year;
+  year: CalendarYear;
 }
 const Year: React.FC<YearProps> = ({ year }) => {
   return (

--- a/src/libs/christian-calendar.ts
+++ b/src/libs/christian-calendar.ts
@@ -4,7 +4,6 @@ import Easter from "./easter";
 
 
 // Library for computing the Christian calendar seasons and colors
-namespace ChristianCalendar {
 
 
   // Compute the start of advent for a given calendar year
@@ -68,8 +67,8 @@ namespace ChristianCalendar {
   // Convenience function to yield a color from a string
   export function colorize(name: string): Color {
     const color = palette.get(_cleanColorName(name));
-    if (!color) 
-    throw new Error(`Invalid color: "${name}" - valid ones are "${Array.from(ChristianCalendar.palette.keys()).join('", "')}"`);
+    if (!color)
+    throw new Error(`Invalid color: "${name}" - valid ones are "${Array.from(palette.keys()).join('", "')}"`);
     return color;
 
   }
@@ -189,6 +188,4 @@ namespace ChristianCalendar {
      let advent = computeAdvent(_date.year);
      return (advent.getTime() <= _date.getTime() ? 1 : 0) + _date.year;
   }
-}
 
-export default ChristianCalendar;


### PR DESCRIPTION
## Summary
- drop the `namespace ChristianCalendar` wrapper
- expose calendar helpers as named exports
- update components and tests to use the new exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68686d4353508331bb8d410f4f456ccb