### PR TITLE
Fix getSeason date handling

### DIFF
--- a/spec/christian-calendar.test.ts
+++ b/spec/christian-calendar.test.ts
@@ -77,6 +77,7 @@ describe("getSeason", () => {
     [new DateWithoutTime("2020-12-25"), "Christmas"],
     [new DateWithoutTime("2020-12-01"), "Advent 1-2"],
     [new DateWithoutTime("2020-04-01"), "Lent"],
+    [new Date("2020/04/01"), "Lent"],
     [new DateWithoutTime("2020-11-28"), "Christ the King"],
   ])("The season for %p should be %s", (date, expectedSeason) => {
     expect(ChristianCalendar.getSeason(date).name).toEqual(expectedSeason);

--- a/src/libs/christian-calendar.ts
+++ b/src/libs/christian-calendar.ts
@@ -173,11 +173,12 @@ namespace ChristianCalendar {
   // Some dates include multiple seasons.  This function returns the
   // first season that includes the date.
   export function getSeason(date: Date | DateWithoutTime): Season {
-    const seasons: Season[] = (new Year(yearFor(date))).seasons
+    const normalized = date instanceof Date ? new DateWithoutTime(date) : date;
+    const seasons: Season[] = (new Year(yearFor(normalized))).seasons
     let index = -1;
 
     // linear search for the first season that includes the date
-    while (index < seasons.length - 1 && seasons[index + 1].startDate.getTime() <= date.getTime()) {
+    while (index < seasons.length - 1 && seasons[index + 1].startDate.getTime() <= normalized.getTime()) {
       index++;
     }
 


### PR DESCRIPTION
## Summary
- normalize Date inputs to DateWithoutTime in `getSeason`
- add test covering `getSeason` with a `Date`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686899b46900833191f49ffbf36f91cf