### PR TITLE
Add LiturgicalCalendar component and export library

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,20 @@
+name: Publish to npm
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org/'
+      - run: npm install
+      - run: npm run build:lib
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 build/
+dist/
 *.log
 .idea/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ If no parameter is passed, the current year is used.
 
 https://ke4roh.github.io/christian-calendar/?year=2020
 
+### Using the React component
+
+The calendar view can also be embedded in your own React application.  Import
+`LiturgicalCalendar` from this package:
+
+```tsx
+import { LiturgicalCalendar } from 'christian-calendar';
+
+export default function Example() {
+  return <LiturgicalCalendar />;
+}
+```
+
+You may supply a `year` prop to control the displayed church year and an
+`onYearChange` callback to respond when the user navigates between years.
+
 ## Local Development
 
 1. Install dependencies:
@@ -39,3 +55,22 @@ To generate a coverage report:
 ```bash
 npm run coverage
 ```
+
+### Building the library
+
+Compiled library files can be generated with:
+
+```bash
+npm run build:lib
+```
+
+The output is written to the `dist/` directory and can be published to npm or
+another registry.
+
+### Publishing to npm
+
+This repository includes a GitHub Action that publishes the compiled library to
+npm whenever a GitHub release is published. To enable publishing, create an
+`NPM_TOKEN` secret in your repository settings containing an npm access token
+with permission to publish the package. The workflow will run `npm run build:lib`
+and `npm publish` using this token.

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "Christian Calendar",
   "version": "1.0.0",
   "type": "module",
-  "main": "index.tsx",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest",
     "quickTest": "jest --bail --onlyFailures",
     "coverage": "jest --coverage",
     "start": "react-scripts start",
     "build": "react-scripts build --entry ./src/index.tsx",
+    "build:lib": "tsc -p tsconfig.build.json",
     "eject": "react-scripts eject"
   },
   "homepage": "./",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import Year from './components/Year';
-import { Year as CalendarYear, yearFor } from './libs/christian-calendar';
-import './App.css';
+import LiturgicalCalendar from './components/LiturgicalCalendar';
+import { yearFor } from './libs/christian-calendar';
 
 function App() {
-  const [year, setYear] = useState<CalendarYear | null>(null);
+  const [year, setYear] = useState<number | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -22,24 +21,15 @@ function App() {
     }
 
 
-    const newYear = new CalendarYear(effectiveYear);
-
-    setYear(newYear);
+    setYear(effectiveYear);
   }, [location.search]);
 
-  const navigateToYear = (increment: number) => {
-    const newYear = (year ? year.year : new Date().getFullYear()) + increment;
+  const handleYearChange = (newYear: number) => {
     navigate(`?year=${newYear}`);
   };
 
   return (
-   <div className={"year-demo-container"}>
-     <div className={"year-nav-button-container"}>
-     <button onClick={() => navigateToYear(-1)}>Previous Year</button>
-     <button onClick={() => navigateToYear(1)}>Next Year</button>
-     </div>
-     {year ? <Year year={year} /> : <div>Loading...</div>}
-   </div>
+    <LiturgicalCalendar year={year ?? undefined} onYearChange={handleYearChange} />
   );
 }
 

--- a/src/components/LiturgicalCalendar.tsx
+++ b/src/components/LiturgicalCalendar.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+import Year from './Year';
+import { Year as CalendarYear, yearFor } from '../libs/christian-calendar';
+import '../App.css';
+
+interface LiturgicalCalendarProps {
+  /**
+   * Year of the church calendar to display. If omitted the component
+   * will calculate the current church year on mount.
+   */
+  year?: number;
+  /**
+   * Callback invoked whenever the displayed year changes due to user
+   * interaction.
+   */
+  onYearChange?: (year: number) => void;
+}
+
+const LiturgicalCalendar: React.FC<LiturgicalCalendarProps> = ({ year, onYearChange }) => {
+  const [currentYear, setCurrentYear] = useState<CalendarYear>(
+    new CalendarYear(year ?? yearFor(new Date()))
+  );
+
+  useEffect(() => {
+    if (year !== undefined && year !== currentYear.year) {
+      setCurrentYear(new CalendarYear(year));
+    }
+  }, [year]);
+
+  const changeYear = (increment: number) => {
+    const newYearNumber = currentYear.year + increment;
+    if (year === undefined) {
+      setCurrentYear(new CalendarYear(newYearNumber));
+    }
+    if (onYearChange) {
+      onYearChange(newYearNumber);
+    }
+  };
+
+  return (
+    <div className={"year-demo-container"}>
+      <div className={"year-nav-button-container"}>
+        <button onClick={() => changeYear(-1)}>Previous Year</button>
+        <button onClick={() => changeYear(1)}>Next Year</button>
+      </div>
+      <Year year={currentYear} />
+    </div>
+  );
+};
+
+export default LiturgicalCalendar;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { default as LiturgicalCalendar } from './components/LiturgicalCalendar';
+export * from './libs/christian-calendar';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- factor year rendering into new `LiturgicalCalendar` component
- update app to use the new component
- add package entry point and build configuration
- document component usage and build step
- add GitHub workflow to publish to npm

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68689c2441d083319d0d2c5bfcc8d92a