### PR TITLE
Fix GitHub Pages path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
         - name: Install dependencies
           run: npm install
         - name: Build
+          env:
+            PUBLIC_URL: https://ke4roh.github.io/christian-calendar
           run: |
             npm test
             npm run build

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:lib": "tsc -p tsconfig.build.json",
     "eject": "react-scripts eject"
   },
-  "homepage": "./",
+  "homepage": "https://github.com/ke4roh/christian-calendar",
   "eslintConfig": {
     "extends": [
       "react-app",


### PR DESCRIPTION
## Summary
- keep npm homepage pointed at repo
- override PUBLIC_URL during GitHub Pages build so assets load from /christian-calendar/

## Testing
- `npm test --silent --runInBand`
- `npm run build`
- `PUBLIC_URL=https://ke4roh.github.io/christian-calendar npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68697cdbf5d883319e2013fde9b18cb1