### PR TITLE
Fix GitHub Pages path

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:lib": "tsc -p tsconfig.build.json",
     "eject": "react-scripts eject"
   },
-  "homepage": "./",
+  "homepage": "https://ke4roh.github.io/christian-calendar",
   "eslintConfig": {
     "extends": [
       "react-app",


### PR DESCRIPTION
## Summary
- keep npm homepage pointed at GitHub Pages URL
- rely on default CRA behavior when building

## Testing
- `npm test --silent --runInBand`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68697cdbf5d883319e2013fde9b18cb1